### PR TITLE
hotfix: critical bug fixed

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -47,9 +47,10 @@ bot.on('inline_query', async (ctx) => {
 })
 
 privateChatBot.use(userAuthMiddleware)
-groupChatBot.use(groupAuthMiddleware)
+privateChatBot.use(scenes)
 
-bot.use(scenes)
+groupChatBot.use(groupAuthMiddleware)
+groupChatBot.use(scenes)
 
 // Private chat commands
 privateChatBot.command(


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed middleware registration order by moving the scenes composer from the main bot instance to the chat-type specific bot instances (`privateChatBot` and `groupChatBot`). This ensures scenes are properly available after authentication middleware runs, preventing scenarios where scenes context might not be accessible in auth middlewares that call `ctx.scenes.enter()`.

**Key Changes:**
- Removed `bot.use(scenes)` which was applying scenes globally after chat-type routing
- Added `privateChatBot.use(scenes)` to apply scenes to private chats after user authentication
- Added `groupChatBot.use(scenes)` to apply scenes to group chats after group authentication
- Middleware order now: session → scenes.manager() → chat-type routing → auth → scenes composer → handlers

This fix ensures that both authentication middlewares (`userAuthMiddleware` and `groupAuthMiddleware`) can successfully call `ctx.scenes.enter()` for initial setup flows without encountering undefined scene context errors.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it fixes a critical middleware ordering bug
- The change correctly addresses a middleware ordering issue where scenes weren't available in authentication middlewares that need to call ctx.scenes.enter(). The fix is minimal, focused, and follows Grammy's middleware composition pattern correctly.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| server.ts | Fixed middleware ordering: moved scenes middleware to chat-type specific bots instead of main bot |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User/Group
    participant B as Bot
    participant S as Session Middleware
    participant SM as Scenes Manager
    participant CB as Chat-Type Bot
    participant A as Auth Middleware
    participant SC as Scenes Composer
    participant H as Handler

    U->>B: Incoming Message
    B->>S: Process Session
    S->>SM: Initialize Scenes
    SM->>CB: Route to Chat-Type Bot
    
    alt Private Chat
        CB->>A: userAuthMiddleware
        A->>SC: privateChatBot scenes
        SC->>H: Execute Command/Handler
    else Group Chat
        CB->>A: groupAuthMiddleware
        A->>SC: groupChatBot scenes
        SC->>H: Execute Command/Handler
    end
    
    H-->>U: Response
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->