### PR TITLE
Hotfix/critical

### DIFF
--- a/middlewares/auth.ts
+++ b/middlewares/auth.ts
@@ -78,7 +78,8 @@ export async function groupAuthMiddleware(ctx: BotContext, next: NextFunction) {
     ctx.message?.entities?.some((entity) => entity.type === 'bot_command') ||
     ctx.message?.caption_entities?.some((entity) => entity.type === 'bot_command') ||
     ctx.message?.reply_to_message?.from?.id === ctx.me?.id ||
-    (ctx.me?.username && ctx.message?.text?.includes(`@${ctx.me.username}`))
+    (ctx.me?.username &&
+      (ctx.message?.text?.includes(`@${ctx.me.username}`) || ctx.message?.caption?.includes(`@${ctx.me.username}`)))
 
   if (!isInteractingWithBot) return next()
 

--- a/server.ts
+++ b/server.ts
@@ -183,7 +183,7 @@ if (env.WEBHOOK_ENABLED) {
         console.info('Bot successfully started')
 
         // Delete commands before setting new ones
-        await bot.api.deleteMyCommands()
+        await bot.api.deleteMyCommands({ scope: { type: 'all_group_chats' } })
 
         // Set commands for private chats
         await bot.api.setMyCommands(


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR optimizes group chat message handling by only enforcing admin permissions when users actually interact with the bot, and properly cleans up group commands on bot startup.

**Key Changes:**
- Added `isInteractingWithBot` check in `groupAuthMiddleware` to skip admin verification for non-bot-directed messages
- Bot interaction detection includes: bot commands in text/captions, replies to bot messages, and `@botname` mentions
- Scoped command deletion to `all_group_chats` only before resetting commands, preventing stale command accumulation
- Addresses previous feedback by including caption support for both commands and mentions

**Impact:**
- Reduces unnecessary API calls to `getChatAdministrators()` for every group message
- Prevents admin permission errors for users who aren't interacting with the bot
- Ensures clean command state on bot startup without affecting private chat commands

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no critical issues
- Both changes are well-implemented optimizations that address previous feedback. The bot interaction detection properly handles all edge cases (commands, captions, replies, mentions), and the scoped command deletion prevents unintended side effects
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| middlewares/auth.ts | Added bot interaction detection to prevent unnecessary admin checks on all group messages; properly handles commands in both text and captions |
| server.ts | Added scoped command deletion for group chats only before setting new commands, preventing stale command accumulation |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant GroupMessage
    participant groupAuthMiddleware
    participant Database
    participant AdminCheck
    participant Scene

    User->>GroupMessage: Send message in group
    GroupMessage->>groupAuthMiddleware: Process message
    
    groupAuthMiddleware->>Database: Check memory cache for group
    alt Group in cache
        Database-->>groupAuthMiddleware: Return cached group
    else Group not in cache
        Database-->>groupAuthMiddleware: Query database
        Database-->>groupAuthMiddleware: Store in cache
    end
    
    alt Group not found or inactive
        groupAuthMiddleware->>Scene: Enter GroupStart
    else Group found and active
        groupAuthMiddleware->>groupAuthMiddleware: Check isInteractingWithBot
        Note over groupAuthMiddleware: Checks: bot_command entities,<br/>caption_entities, replies to bot,<br/>`@botname` mentions in text/caption
        
        alt Not interacting with bot
            groupAuthMiddleware->>Scene: Continue (skip admin check)
        else Interacting with bot
            groupAuthMiddleware->>AdminCheck: Get chat administrators
            alt User is admin
                AdminCheck-->>groupAuthMiddleware: Authorized
                groupAuthMiddleware->>Scene: Continue to next handler
            else User is not admin
                AdminCheck-->>groupAuthMiddleware: Not authorized
                groupAuthMiddleware->>User: Reply with nonAdminPermission error
            end
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->