### PR TITLE
 fix: correct prayer time calculation when server runs in UTC

### DIFF
--- a/cron/cron.ts
+++ b/cron/cron.ts
@@ -75,7 +75,7 @@ async function daily(bot: Bot<BotContext>) {
   const activeRegionIds: number[] = [...new Set([...userRegionIds, ...groupRegionIds])]
 
   for (const regionId of activeRegionIds) {
-    const region = getPrayerTimes(regionId, now.toDate())
+    const region = getPrayerTimes(regionId, now)
     if (!region) continue
 
     const prayerOpts = buildPrayerOpts(region, date)
@@ -142,7 +142,7 @@ async function reminder(bot: Bot<BotContext>) {
   const allRegionIds = getRegionIds()
 
   for (const regionId of allRegionIds) {
-    const region = getPrayerTimes(regionId, now.toDate())
+    const region = getPrayerTimes(regionId, now)
     if (!region) continue
 
     for (const { name, getMessage } of PRAYER_NOTIFICATIONS) {

--- a/query/inline.ts
+++ b/query/inline.ts
@@ -66,7 +66,7 @@ export async function inlineQuery(ctx: BotContext) {
 
   for (const match of matches) {
     const region = match.original
-    const prayerTimes = getPrayerTimes(region.id, now.toDate())
+    const prayerTimes = getPrayerTimes(region.id, now)
     if (!prayerTimes) continue
 
     const content = t(($) => $.infoPrayTime, {

--- a/scenes/group-location.ts
+++ b/scenes/group-location.ts
@@ -65,7 +65,7 @@ scene.wait('group_location_update').on('callback_query:data', async (ctx) => {
       await ctx.answerCallbackQuery()
 
       const now = dayjs()
-      const data = getPrayerTimes(+inputData, now.toDate())
+      const data = getPrayerTimes(+inputData, now)
       if (!data || !ctx.chat) return ctx.scene.exit()
 
       const regionName = regionsData.find((r) => r.id === data.regionId)?.name ?? ''

--- a/scenes/group-start.ts
+++ b/scenes/group-start.ts
@@ -65,7 +65,7 @@ scene.wait('group_location').on('callback_query:data', async (ctx) => {
       await ctx.answerCallbackQuery()
 
       const now = dayjs()
-      const data = getPrayerTimes(+inputData, now.toDate())
+      const data = getPrayerTimes(+inputData, now)
       if (!data || !ctx.chat) return ctx.scene.exit()
 
       const regionName = regionsData.find((r) => r.id === data.regionId)?.name ?? ''

--- a/scenes/location.ts
+++ b/scenes/location.ts
@@ -65,7 +65,7 @@ scene.wait('location').on('callback_query:data', async (ctx) => {
       await ctx.answerCallbackQuery()
 
       const now = dayjs()
-      const data = getPrayerTimes(+inputData, now.toDate())
+      const data = getPrayerTimes(+inputData, now)
       if (!data) return ctx.scene.exit()
 
       const regionName = regionsData.find((r) => r.id === data.regionId)?.name ?? ''

--- a/scenes/search.ts
+++ b/scenes/search.ts
@@ -112,7 +112,7 @@ scene.wait('commonDays').on('callback_query:data', async (ctx) => {
       day = Number(dayInput)
       break
   }
-  const data = getPrayerTimes(ctx.session.selectedRegionId, new Date(now.get('year'), now.get('month'), day))
+  const data = getPrayerTimes(ctx.session.selectedRegionId, now.date(day))
 
   if (!data) return ctx.scene.exit()
 

--- a/scenes/start.ts
+++ b/scenes/start.ts
@@ -105,7 +105,7 @@ scene.wait('the_end').on('callback_query:data', async (ctx) => {
   const fasting = keyboardMessage[0] === ctx.update.callback_query.data
 
   const now = dayjs()
-  const data = getPrayerTimes(ctx.session.selectedRegionId, now.toDate())
+  const data = getPrayerTimes(ctx.session.selectedRegionId, now)
   if (!data) return ctx.scene.exit()
 
   const regionName = regionsData.find((r) => r.id === data.regionId)?.name ?? ''

--- a/utils/prayerTimes.ts
+++ b/utils/prayerTimes.ts
@@ -1,6 +1,7 @@
 import { CalculationMethod, Coordinates, Madhab, PrayerTimes } from 'adhan'
 import regions from '#config/regions.json'
 import dayjs from './dayjs'
+import { ConfigType as DayJsInput } from 'dayjs'
 
 export interface PrayerTimesResult {
   region: string
@@ -23,7 +24,7 @@ function formatTime(date: Date): string {
 
 /** Computes prayer times for a region using the adhan library.
  *  Uses custom fajr/isha angles (15.5°) matching islom.uz and Hanafi madhab. */
-export function getPrayerTimes(regionId: number, date: Date): PrayerTimesResult | null {
+export function getPrayerTimes(regionId: number, date: DayJsInput): PrayerTimesResult | null {
   const region = regions.find((r) => r.id === regionId)
 
   if (!region) return null
@@ -34,7 +35,12 @@ export function getPrayerTimes(regionId: number, date: Date): PrayerTimesResult 
   params.ishaAngle = 15.5
   params.madhab = Madhab.Hanafi
 
-  const prayerTimes = new PrayerTimes(coordinates, date, params)
+  // adhan extracts date via getFullYear/getMonth/getDate (server-local timezone).
+  // When the server runs in UTC, 01:00 Tashkent = 20:00 UTC (previous day),
+  // so adhan would calculate yesterday's prayer times. Fix by converting to UTC
+  // while keeping local time.
+  const correctedDate = dayjs(date).utc(true).toDate()
+  const prayerTimes = new PrayerTimes(coordinates, correctedDate, params)
 
   return {
     region: region.name,


### PR DESCRIPTION
  adhan library extracts date components using server-local timezone,
  so 01:00 Tashkent (20:00 UTC previous day) would yield yesterday's
  prayer times on a UTC server. Fix by constructing a Date whose local
  components match the Tashkent calendar date via dayjs's utc(true).

  Also refactor getPrayerTimes to accept DayJsInput instead of Date,
  removing redundant .toDate() calls at all call sites.
